### PR TITLE
Change unexpected "undefined" to "null" in AdaptiveCardPlayer.tsx

### DIFF
--- a/packages/copilot-studio-adaptive-card-player/src/private/AdaptiveCardPlayer.tsx
+++ b/packages/copilot-studio-adaptive-card-player/src/private/AdaptiveCardPlayer.tsx
@@ -35,7 +35,7 @@ const _ = () => {
     return card ? card.content : firstBotMessageActivity && buildChatCard(firstBotMessageActivity);
   }, [firstBotMessageActivity]);
 
-  return card && <AdaptiveCardContent content={card} />;
+  return !!card ? <AdaptiveCardContent content={card} /> : null;
 };
 
 export default memo(function AdaptiveCardPlayer({ directLine, store }: Props) {


### PR DESCRIPTION
React (or the minified SharePoint react) is expecting `null` if nothing is to be rendered, `undefined` causes a react error and the component hooks then aren't run and the component isn't updated.